### PR TITLE
OpenGL Compatibility Fix

### DIFF
--- a/LotRRealmsInExileDev/gfx/FX/court_scene.shader
+++ b/LotRRealmsInExileDev/gfx/FX/court_scene.shader
@@ -1792,6 +1792,14 @@ Effect standard_selection_mapobject
 	PixelShader = "PS_noop"
 }
 
+# MOD(lotr)
+Effect snap_to_terrain_selection_mapobject
+{
+	VertexShader = "VS_standard"
+	PixelShader = "PS_noop"
+}
+# END MOD
+
 Effect snap_to_terrain_atlas_selection_mapobject
 {
 	VertexShader = "VS_standard"
@@ -1893,6 +1901,14 @@ Effect snap_to_terrain
 	VertexShader = "VS_standard"
 	PixelShader = "PS_noop"
 }
+
+# MOD(lotr)
+Effect snap_to_terrain_mapobject
+{
+	VertexShader = "VS_standard"
+	PixelShader = "PS_noop"
+}
+# END MOD
 
 Effect snap_to_terrain_atlas
 {

--- a/LotRRealmsInExileDev/gfx/FX/jomini/jomini_province_overlays.fxh
+++ b/LotRRealmsInExileDev/gfx/FX/jomini/jomini_province_overlays.fxh
@@ -114,7 +114,7 @@ PixelShader =
 		float LOTR_GetOverlayAlphaMultiplier(in float3 OverlayColor)
 		{
 			static const float3 DISCARDED_OVERLAY_COLOR     = float3(0.0f, 0.0f, 0.0f);
-			static const float3 DISCARDED_OVERLAY_TOLERANCE = 0.01f;
+			static const float  DISCARDED_OVERLAY_TOLERANCE = 0.01f;
 
 			return step(DISCARDED_OVERLAY_TOLERANCE, distance(OverlayColor.rgb, DISCARDED_OVERLAY_COLOR));
 		}


### PR DESCRIPTION
This fixes a silly GLSL compilation error in `jomini_province_overlays.fxh` shader, which prevented the map from rendering in OpenGL mode on Linux (tested) and presumably on macOS too.

Additionally, a couple of benign shader-related errors from `error.log` have been suppressed via dummy definitions in `court_scene.shader`.