### PR TITLE
Restored Map Names Fading at Shallow Camera Angles

### DIFF
--- a/LotRRealmsInExileDev/gfx/FX/mapname.shader
+++ b/LotRRealmsInExileDev/gfx/FX/mapname.shader
@@ -1,5 +1,3 @@
-### Code to not render title names over black province colouring
-
 Includes = {
 	"jomini/countrynames.fxh"
 	"jomini/jomini_fog.fxh"

--- a/LotRRealmsInExileDev/gfx/FX/mapname.shader
+++ b/LotRRealmsInExileDev/gfx/FX/mapname.shader
@@ -71,7 +71,8 @@ PixelShader =
 			// float4 TextColor = float4( 0, 0, 0, 1 );
 			// float4 OutlineColor = float4( 1, 1, 1, 1 );
 
-			float LOTR_OverlayAlphaMultiplier   = LOTR_GetOverlayAlphaMultiplierAtWorldSpacePosXZ(Input.WorldSpacePos.xz);
+			//float LOTR_OverlayAlphaMultiplier   = LOTR_GetOverlayAlphaMultiplierAtWorldSpacePosXZ(Input.WorldSpacePos.xz);
+			float LOTR_OverlayAlphaMultiplier   = 1.0f; // Replace with the previous line to hide map names over black map overlay
 			float GH_CameraPitchAlphaMultiplier = GH_GetDefaultCameraPitchAlphaMultiplier();
 
 			float LOTR_Alpha = LOTR_OverlayAlphaMultiplier*GH_CameraPitchAlphaMultiplier;


### PR DESCRIPTION
The removal of `mapname.shader` in bb35cdc was AFAICT intended to disable hiding map names over regions with black map overlay.

However, said file also implemented another piece of logic, namely - gradual fading of all map names in sync with the surround mask whenever the camera pitches to reveal the skybox. Said logic stopped being applied as well, leading to map names being visible through mountains and such at shallow camera angles at certain zoom levels.

This PR restores `mapname.shader` and disables the exact line responsible for hiding names over black overaly, while leaving the rest of the logic intact.