### PR TITLE
Court Banners Glow Fix

### DIFF
--- a/LotRRealmsInExileDev/gfx/FX/court_scene.shader
+++ b/LotRRealmsInExileDev/gfx/FX/court_scene.shader
@@ -1664,7 +1664,10 @@ Effect court_usercolor
 	VertexShader = "VS_standard"
 	PixelShader = "PS_court"
 
-	Defines = { "USER_COLOR" }
+	# MOD(godherja)
+	#Defines = { "USER_COLOR" }
+	Defines = { "USER_COLOR" "GH_EMISSION_DISABLED" }
+	# END MOD
 }
 
 Effect court_usercolor_coa
@@ -1672,7 +1675,10 @@ Effect court_usercolor_coa
 	VertexShader = "VS_standard"
 	PixelShader = "PS_court"
 
-	Defines = { "USER_COLOR" "COA" }
+	# MOD(godherja)
+	#Defines = { "USER_COLOR" "COA" }
+	Defines = { "USER_COLOR" "COA" "GH_EMISSION_DISABLED" }
+	# END MOD
 }
 
 Effect courtShadow


### PR DESCRIPTION
This fixes the issue where court banners and other assets using `court_usercolor` and `court_usercolor_coa` shaders would have unintended glow.