### PR TITLE
standard_winter Errors and Rendering Artifacts Fix

### DIFF
--- a/LotRRealmsInExileDev/gfx/FX/court_scene.shader
+++ b/LotRRealmsInExileDev/gfx/FX/court_scene.shader
@@ -2247,3 +2247,23 @@ Effect SKYX_sky_selection_mapobject
 	PixelShader = "PS_noop"
 }
 # END MOD
+
+# MOD(godherja)
+Effect standard_winter_mapobject
+{
+	VertexShader = "VS_standard"
+	PixelShader = "PS_noop"
+}
+
+Effect standard_winterShadow_mapobject
+{
+	VertexShader = "VS_standard"
+	PixelShader = "PS_noop"
+}
+
+Effect standard_winter_selection_mapobject
+{
+	VertexShader = "VS_standard"
+	PixelShader = "PS_noop"
+}
+# END MOD

--- a/LotRRealmsInExileDev/gfx/FX/pdxmesh.shader
+++ b/LotRRealmsInExileDev/gfx/FX/pdxmesh.shader
@@ -1003,3 +1003,17 @@ Effect courtShadow
 	RasterizerState = ShadowRasterizerState
 }
 
+# MOD(godherja)
+Effect standard_winter_mapobject
+{
+	VertexShader = "VS_mapobject"
+	PixelShader = "PS_standard"
+	Defines = { "APPLY_WINTER" }
+}
+
+Effect standard_winterShadow_mapobject
+{
+	VertexShader = "VS_jomini_mapobject_shadow"
+	PixelShader = "PS_jomini_mapobject_shadow"
+}
+# END MOD


### PR DESCRIPTION
This fixes `standard_winter`-related `Failed getting Effect` log errors and graphical artifacts, that appeared after 6f3bcd3.
The commit in question contains valid changes and does **not** need to be reverted, provided this PR gets merged.

These minor shader edits are needed for the switch to `standard_winter` to work correctly in all cases ¹.
(Apologies for not realising as much sooner.)

(If 6f3bcd3 gets reverted by the time this PR is merged, it will be safe to un-revert it after merging this.)

<hr/>
¹ Boring technical details are available under the spoiler below.
<br/><br/>
<details>
<summary><a name="technical-details"></a>Why do we even need this change compared to vanilla? (Boring technical details.)</summary>

### Some background on `*_mapobject` shader variants

For some map objects (iirc, the ones placed manually, rather than via a locator), the game implicitly appends `_mapobject` to the name of the shader that was specified for it in the `.asset` file.

So, for example an asset with `shader = "standard"` will sometimes be actually rendered using `standard_mapobject`.
The difference is purely technical - the way that the game calculates vertex coordinates is different, but visuals themselves remain the same.

Accordingly, vanilla game defines `_mapobject` variants for _**almost**_ every shader used on the map: `standard_mapobject`, `snap_to_terrain_atlas_mapobject` etc. - those are not for devs (or modders) to use directly, but just to internally accommodate this mechanism.

### Why doesn't vanilla have this `standard_winter_mapobject` definition?

It just so happens, that vanilla only ever uses `standard_winter` for holding models and such - objects that don't require this `_mapobject` treatment.
So the devs have neglected to include `standard_winter_mapobject` definition in `pdxmesh.shader` and it works fine for vanilla, pretty much by happy coincidence.
(The rest of vanilla winter-compatible models are covered by `standard_atlas`, `snap_to_terrain` etc. - other shaders that support winter like `standard_winter`, but do also come with a `_mapobject` variant defined.)

But it doesn't work fine in all cases where _we_ might want to use `standard_winter` - as evident by the current errors screaming about missing `standard_winter_mapobject`. Which is why we have to introduce it ourselves mod-side, for `standard_winter` to become a drop-in replacement for `standard`.

Ideally, PDX would just have this `standard_winter_mapobject` definition in vanilla (maybe they'll add it in a future patch, realizing they've forgotten it). But for now we simply need to define it ourselves, which is what this PR does.
</details>