### PR TITLE
Clouds are no longer rendered on top of map table & environment

### DIFF
--- a/LotRRealmsInExileDev/gfx/FX/gh_vic3_fog_of_war.fxh
+++ b/LotRRealmsInExileDev/gfx/FX/gh_vic3_fog_of_war.fxh
@@ -351,6 +351,12 @@ PixelShader = {
 				float ShadowTex = smoothstep( _FoWShadowTexStart, _FoWShadowTexStop, SampleFowNoiseShadow( Coordinate ) );
 			#endif
 
+			// MOD(godherja)
+			// Prevent clouds from showing up on top of map table & environment
+			CloudTex  = lerp(CloudTex, 0.0f, FlatMapLerp);
+			ShadowTex = lerp(ShadowTex, 0.0f, FlatMapLerp);
+			// END MOD
+
 			// Apply Fog of war and cloud shadow
 			float3 FinalColor = lerp( Color, _FoWShadowColor.rgb, _FoWShadowMult * ShadowAlpha );					// Fow darkness
 			FinalColor = lerp( FinalColor, _FoWShadowColor.rgb, _FoWShadowMult * ShadowTex * ShadowMultiplier );	// Cloud Shadow


### PR DESCRIPTION
This fixes the issue introduced with the update to v1.12, where clouds texture would be rendered on top of the new map table, floor and artifacts in the table environment.

![image](https://github.com/jj248/RealmsInExile/assets/1268105/d7a39ce1-90dd-4cb3-8c38-6b77e2c61528)
